### PR TITLE
Mobile-friendly 2020 announcement

### DIFF
--- a/src/styles/main.pcss
+++ b/src/styles/main.pcss
@@ -234,7 +234,9 @@ input {
 
 #header2020 {
   @mixin fill-pattern-green-leaf;
-  height: 60px;
+  min-height: 60px;
+  padding: 15px;
+  line-height: 35px;
   display: flex;
   text-align: center;
   color: white;


### PR DESCRIPTION
Before:

![Screenshot_20190910-164333](https://user-images.githubusercontent.com/48325/64652790-51d17400-d3ea-11e9-9525-14b1514b4e65.png)

After:

<img width="369" alt="Captura de Pantalla 2019-09-10 a la(s) 16 41 29" src="https://user-images.githubusercontent.com/48325/64652798-5564fb00-d3ea-11e9-8b1b-25fbfe92e2a9.png">
