### PR TITLE
Add link to videos

### DIFF
--- a/src/View/Nav.elm
+++ b/src/View/Nav.elm
@@ -27,6 +27,13 @@ links additionalLinks =
         |> Dom.appendChildList
             ([ linkWrapper |> Dom.appendChild (link "Details")
              , linkWrapper |> Dom.appendChild (link "Speakers")
+             , linkWrapper
+                |> Dom.appendChild
+                    (Dom.element "a"
+                        |> Dom.addAttribute (href "https://www.youtube.com/elminthespring")
+                        |> Dom.addAttribute (target "_blank")
+                        |> Dom.appendText "Videos"
+                    )
              ]
                 ++ additionalLinks
             )


### PR DESCRIPTION
Now that 2020 is going, people will likely look back to the 2019 site to see what the conference is about. We should have a prominent link to the videos. 

This PR adds that link to the nav, opening in a new tab.

<img width="1322" alt="Screen Shot 2019-12-30 at 10 00 46" src="https://user-images.githubusercontent.com/48325/71589698-68abeb80-2aeb-11ea-9df0-1bb7d42ceab2.png">
